### PR TITLE
Fix the instruction of installing dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ```sh
 git clone https://github.com/Ikuyadeu/review_pattern_gen.git
 cd review_pattern_gen
-pip3 install antlr4-python3-runtime, prefixspan, PyGithub
+pip3 install antlr4-python3-runtime prefixspan PyGithub unidiff
 git clone https://github.com/Ikuyadeu/CodeTokenizer.git
 ```
 


### PR DESCRIPTION
This project requires [unidiff](https://pypi.org/project/unidiff/).

Also, I fixed the line of running `pip install`. It should receive multiple packages as a space delimited list.