### PR TITLE
Do not parse timezone "Z"

### DIFF
--- a/collector/pulls_collector.py
+++ b/collector/pulls_collector.py
@@ -118,7 +118,7 @@ class PullsCollector:
         }
 
     def _parse_datetime(self, d: str) -> datetime:
-        return datetime.strptime(d, '%Y-%m-%dT%H:%M:%S%z')
+        return datetime.strptime(d, '%Y-%m-%dT%H:%M:%SZ')
 
     def _compare_url(self, base: str, head: str) -> str:
         return f'https://github.com/{self._repo_owner}/{self._repo_name}/compare/{base}...{head}.diff'


### PR DESCRIPTION
`'%z'` directive passed to `datetime.strptime()` is parsed as
`'+00:00'`, but this feature is added in Python 3.7.

Currently, PyPy's latest version is compatible with Python 3.6, so
I decided not to parse timezone.

Although `datetime` instances will be "naive" without timezone,
there are no problems because `collect_pulls.py` just writes `datetime`
objects into CSV files as string.