### PR TITLE
Replace the "condition" and "consequent"

### DIFF
--- a/collect_changes.py
+++ b/collect_changes.py
@@ -214,8 +214,8 @@ def make_master_diff(target_repo, owner, repo, branch, abstracted):
             "author":author,
             "created_at": created_at,
             # "file_path": x["file_path"],
-            "condition": x["consequent"],
-            "consequent": x["condition"],
+            "condition": x["condition"],
+            "consequent": x["consequent"],
             "abstracted": x["abstracted"] if abstracted else {}
         } for x in hunks]
         change_sets.extend(out_metricses)


### PR DESCRIPTION
Thanks for sharing this awesome tool.

When printing the final hunk diff info in make_master_diff function, the key values are placed in reverse.

(make_pull_diff function is correct.)